### PR TITLE
fix(postgres): correct startup command in production docker-compose

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -149,14 +149,7 @@ services:
       options:
         max-size: "100m"
         max-file: "3"
-    command: >
-      postgres
-      -c config_file=/etc/postgresql/postgresql.conf
-      -c log_statement=mod
-      -c log_min_duration_statement=1000
-      -c log_checkpoints=on
-      -c log_connections=on
-      -c log_disconnections=on
+    command: sh -c "service postgresql start && sleep infinity"
 
   # ===================================================================
   # Redis Cache Service


### PR DESCRIPTION
The previous command was overriding the default entrypoint of the shangor/postgres-for-rag image, causing the container to fail with an "executable not found" error.

This commit replaces the incorrect command with the one specified in the official Docker Hub documentation for the image, which correctly starts the PostgreSQL service.

<!--
Thanks for contributing to LightRAG!

Please ensure your pull request is ready for review before submitting.

About this template

This template helps contributors provide a clear and concise description of their changes. Feel free to adjust it as needed.
-->

## Description

[Briefly describe the changes made in this pull request.]

## Related Issues

[Reference any related issues or tasks addressed by this pull request.]

## Changes Made

[List the specific changes made in this pull request.]

## Checklist

- [ ] Changes tested locally
- [ ] Code reviewed
- [ ] Documentation updated (if necessary)
- [ ] Unit tests added (if applicable)

## Additional Notes

[Add any additional notes or context for the reviewer(s).]
